### PR TITLE
Make `DrawBuilder` non-consuming

### DIFF
--- a/examples/draw-triangles.rs
+++ b/examples/draw-triangles.rs
@@ -4,8 +4,9 @@ fn main() {
     let mut rugl = rugl::init();
     let count = 10000;
 
-    let draw = rugl.draw()
-        .vert("
+    let draw = {
+        let mut builder = rugl.draw();
+        builder.vert("
             #version 150
             in vec2 position;
             in float id;
@@ -44,8 +45,9 @@ fn main() {
                 }
             }).collect::<Vec<[f32; 2]>>())
         })
-        .count(count)
-        .finalize();
+        .count(count);
+        builder.finalize()
+    };
 
     rugl.frame(|env| {
         draw(env);

--- a/examples/draw.rs
+++ b/examples/draw.rs
@@ -1,10 +1,10 @@
 extern crate rugl;
 
 fn main() {
-    let rugl = rugl::init();
-
-    let draw = rugl.draw()
-        .vert("
+    let mut rugl = rugl::init();
+    let draw = {
+        let mut builder = rugl.draw();
+        builder.vert("
             #version 150
             in vec2 position;
             void main() {
@@ -23,10 +23,10 @@ fn main() {
              0.5, -0.5,
             -0.5, -0.5
         ])
-        .count(3)
-        .finalize();
-
-    rugl.frame(|| {
-        draw();
+        .count(3);
+        builder.finalize()
+    };
+    rugl.frame(|env| {
+        draw(env);
     });
 }

--- a/examples/moving-triangles.rs
+++ b/examples/moving-triangles.rs
@@ -4,8 +4,9 @@ fn main() {
     let mut rugl = rugl::init();
     let count = 1000;
 
-    let draw = rugl.draw()
-        .vert("
+    let draw = {
+        let mut builder = rugl.draw();
+        builder.vert("
             #version 150
             in vec2 position;
             in float id;
@@ -38,7 +39,7 @@ fn main() {
         .uniform("time", Box::new(|env| Box::new(env.time as f32)))
         .uniform("count", {
             let count_in = count.clone() as f32;
-            Box::new(move |env| Box::new(count_in))
+            Box::new(move |_| Box::new(count_in))
         })
         .attribute("position", {
             &((0..(count * 3)).map(|i| {
@@ -56,8 +57,9 @@ fn main() {
                 (i as f32 / 3.0).floor()
             }).collect::<Vec<f32>>())
         })
-        .count(count * 3)
-        .finalize();
+        .count(count * 3);
+        builder.finalize()
+    };
 
     rugl.frame(|env| {
         draw(env);

--- a/src/draw_builder.rs
+++ b/src/draw_builder.rs
@@ -36,24 +36,24 @@ impl DrawBuilder {
         }
     }
 
-    pub fn vert(mut self, source: &'static str) -> DrawBuilder {
+    pub fn vert(&mut self, source: &'static str) -> &mut DrawBuilder {
         self.config.vert = Some(source);
         self
     }
 
-    pub fn frag(mut self, source: &'static str) -> DrawBuilder {
+    pub fn frag(&mut self, source: &'static str) -> &mut DrawBuilder {
         self.config.frag = Some(source);
         self
     }
 
-    pub fn uniform(mut self, name: &str, setter: Box<Fn(&rugl::Environment) -> Box<UniformValue>>) -> DrawBuilder {
+    pub fn uniform(&mut self, name: &str, setter: Box<Fn(&rugl::Environment) -> Box<UniformValue>>) -> &mut DrawBuilder {
         self.config.uniform_setters.insert(name.to_string(), setter);
         self
     }
 
     pub fn attribute(
-        mut self, name: &str, vertices: &BufferableData
-    ) -> DrawBuilder {
+        &mut self, name: &str, vertices: &BufferableData
+    ) -> &mut DrawBuilder {
         // gl_helpers::log_draw!("Adding attribute {:?}", name);
         self.config.attributes.push(
             (name.to_string(), vertices.to_buffer())
@@ -61,7 +61,7 @@ impl DrawBuilder {
         self
     }
 
-    pub fn count(mut self, count: i32) -> DrawBuilder {
+    pub fn count(&mut self, count: i32) -> &mut DrawBuilder {
         self.config.count = count;
         self
     }

--- a/src/rugl.rs
+++ b/src/rugl.rs
@@ -49,9 +49,7 @@ impl Rugl {
         draw_builder::DrawBuilder::new()
     }
 
-    pub fn frame<F>(&mut self, draw: F) where
-        F: Fn(&Environment)
-    {
+    pub fn frame<F: Fn(&Environment)>(&mut self, draw: F) {
         let start_time = self.start_time;
         let mut previous_time = time::precise_time_s();
 


### PR DESCRIPTION
By taking `&mut self` instead of `mut self`, the user will be able to chain calls
[more ergonomically](https://github.com/brson/rust-api-guidelines#the-benefit).

This pattern is recommended by the [Rust API guidelines](https://github.com/brson/rust-api-guidelines#non-consuming-builders-preferred).