### PR TITLE
Fix a typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This is an early experimental prototype for doing OpenGL in Rust using a similar strategy to the WebGL library [regl](http://regl.party/). It is an excuse for me to learn Rust and write some OpenGL.
 
 ## Examples
-* `cargo run --examples draw`
-* `cargo run --examples draw-triangles`
-* `cargo run --examples moving-triangles`
+* `cargo run --example draw`
+* `cargo run --example draw-triangles`
+* `cargo run --example moving-triangles`
 
 MIT License


### PR DESCRIPTION
Executing `cargo run --examples ...` gives me an error but `cargo run --example ...` works for me. I suspect that is a typo.