### PR TITLE
[Bugfix] Update draw example to new .frame(closure) signature.

### DIFF
--- a/examples/draw.rs
+++ b/examples/draw.rs
@@ -1,7 +1,7 @@
 extern crate rugl;
 
 fn main() {
-    let rugl = rugl::init();
+    let mut rugl = rugl::init();
 
     let draw = rugl.draw()
         .vert("
@@ -26,7 +26,7 @@ fn main() {
         .count(3)
         .finalize();
 
-    rugl.frame(|| {
-        draw();
+    rugl.frame(|env| {
+        draw(env);
     });
 }


### PR DESCRIPTION
I guess you forgot to update the draw example when you rewrote the .frame() function to take one closure as a parameter. With this change `cargo test` won't produce any errors.

One caveat is, that you probably intend this example to be easier. Taking an empty environment and passing it on to draw isn't exactly straightforward thing to to. But I'm not sure how you could improve this. I suggest that you still merge this to get the tests to pass in the meantime.